### PR TITLE
fix: reset base styles for responsive layout

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -47,9 +47,9 @@ function Footer() {
           </div>
           <div className="footer-column">
             <h4>Coordonnées</h4>
-            <p>Adresse : Bruxelles, Belgique</p>
-            <p>Téléphone : +32 123 45 67 89</p>
-            <p>Email : info@qpower.be</p>
+            <p>Adresse : Bruxelles, Belgique</p>
+            <p>Téléphone : +32 123 45 67 89</p>
+            <p>Email : info@qpower.be</p>
           </div>
           <div className="footer-column">
             <h4>Suivez‑nous</h4>
@@ -67,7 +67,7 @@ function Footer() {
           </div>
         </div>
         <div className="footer-bottom">
-          <p>© {currentYear} QPower. Tous droits réservés.</p>
+          <p>© {currentYear} QPower. Tous droits réservés.</p>
         </div>
       </div>
     </footer>

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,14 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+/* Base styles reset to ensure responsive layout and override template defaults */
+html,
+body {
+  margin: 0;
+  padding: 0;
 }
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
+  font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
+  color: var(--text-color, #333333);
+  background-color: var(--background-color, #f9f9f9);
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -8,8 +8,8 @@ import '../App.css'
 function Blog() {
   const posts = [
     {
-      title: 'Économies d’énergie : nos conseils',
-      date: '10 août 2025',
+      title: 'Économies d’énergie : nos conseils',
+      date: '10 août 2025',
       excerpt:
         'Réduire votre consommation d’électricité est plus simple qu’il n’y paraît. Découvrez nos astuces pour économiser au quotidien.',
       image:
@@ -17,7 +17,7 @@ function Blog() {
     },
     {
       title: 'Innovations dans les bornes de recharge',
-      date: '5 juillet 2025',
+      date: '5 juillet 2025',
       excerpt:
         'Les nouvelles générations de bornes intelligentes optimisent la charge de votre véhicule et la répartition de la puissance.',
       image:
@@ -25,9 +25,9 @@ function Blog() {
     },
     {
       title: 'Comprendre le photovoltaïque',
-      date: '15 juin 2025',
+      date: '15 juin 2025',
       excerpt:
-        'Comment fonctionne une installation solaire ? Quels sont les composants essentiels et comment choisir la bonne puissance ?',
+        'Comment fonctionne une installation solaire ? Quels sont les composants essentiels et comment choisir la bonne puissance ?',
       image:
         'https://images.unsplash.com/flagged/photo-1566838803980-56bfa5300e8c?auto=format&fit=crop&w=1600&q=80',
     },

--- a/src/pages/BornesRecharge.jsx
+++ b/src/pages/BornesRecharge.jsx
@@ -24,8 +24,8 @@ function BornesRecharge() {
                 entreprises.
               </p>
               <p>
-                Nous installons des bornes de différentes puissances (3,7 kW à
-                22 kW) en fonction de vos besoins et de la capacité de votre
+                Nous installons des bornes de différentes puissances (3,7 kW à
+                22 kW) en fonction de vos besoins et de la capacité de votre
                 installation électrique. Nos techniciens certifiés vous
                 conseillent sur le choix de la borne, réalisent le
                 dimensionnement et assurent la mise en service en toute
@@ -34,7 +34,7 @@ function BornesRecharge() {
               </p>
               <p>
                 En choisissant QPower, vous bénéficiez d’un accompagnement
-                personnalisé : analyse de vos besoins, devis détaillé,
+                personnalisé : analyse de vos besoins, devis détaillé,
                 installation professionnelle et maintenance. Nous pouvons
                 également proposer des solutions de gestion intelligente de la
                 charge pour optimiser votre consommation.

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -25,16 +25,16 @@ function Contact() {
         <div className="container">
           <h1>Contact</h1>
           <p>
-            Une question ? Un projet à nous confier ? N’hésitez pas à nous
+            Une question ? Un projet à nous confier ? N’hésitez pas à nous
             contacter via le formulaire ci‑dessous ou par téléphone.
           </p>
           <div className="contact-container">
             <div className="contact-info">
               <h3>Nos coordonnées</h3>
-              <p>Adresse : Bruxelles, Belgique</p>
-              <p>Téléphone : +32 123 45 67 89</p>
-              <p>Email : info@qpower.be</p>
-              <p>Horaires : du lundi au vendredi, 8h00 – 18h00</p>
+              <p>Adresse : Bruxelles, Belgique</p>
+              <p>Téléphone : +32 123 45 67 89</p>
+              <p>Email : info@qpower.be</p>
+              <p>Horaires : du lundi au vendredi, 8h00 – 18h00</p>
             </div>
             <div className="contact-form-wrapper">
               {submitted ? (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -48,7 +48,7 @@ function Home() {
           <h2>Nos services</h2>
           <p>
             Nous proposons une gamme complète de prestations pour répondre à vos
-            besoins en énergie : électricité générale, installation de bornes de
+            besoins en énergie : électricité générale, installation de bornes de
             recharge et de panneaux solaires.
           </p>
           <div className="services-grid">
@@ -77,7 +77,7 @@ function Home() {
       {/* Call to Action Section */}
       <section className="cta-section">
         <div className="container cta-container">
-          <h2>Prêt·e à franchir le pas ?</h2>
+          <h2>Prêt·e à franchir le pas ?</h2>
           <p>
             Faites confiance à QPower pour optimiser votre consommation
             énergétique et installer des solutions durables.

--- a/src/pages/PanneauxSolaires.jsx
+++ b/src/pages/PanneauxSolaires.jsx
@@ -21,7 +21,7 @@ function PanneauxSolaires() {
                 performants, adaptés à votre toit et à votre consommation.
               </p>
               <p>
-                Nous réalisons une étude approfondie : orientation et
+                Nous réalisons une étude approfondie : orientation et
                 inclinaison du toit, ensoleillement, dimensionnement de la
                 puissance, choix des modules et des onduleurs. Nos équipes
                 certifiées procèdent ensuite à l’installation et au raccordement

--- a/src/pages/Realisations.jsx
+++ b/src/pages/Realisations.jsx
@@ -18,14 +18,14 @@ function Realisations() {
     {
       title: 'Installation d’une borne de recharge',
       description:
-        'Pose d’une borne 7 kW dans un garage de particulier avec contrôle de charge intelligent.',
+        'Pose d’une borne 7 kW dans un garage de particulier avec contrôle de charge intelligent.',
       image:
         'https://upload.wikimedia.org/wikipedia/en/c/cc/Electric_Vehicles_Charging.jpg',
     },
     {
       title: 'Pose de panneaux solaires',
       description:
-        '10 panneaux installés sur une toiture inclinée pour une production annuelle de 3,5 kWc.',
+        '10 panneaux installés sur une toiture inclinée pour une production annuelle de 3,5 kWc.',
       image:
         'https://images.unsplash.com/flagged/photo-1566838803980-56bfa5300e8c?auto=format&fit=crop&w=1600&q=80',
     },

--- a/src/pages/SimulateurDevis.jsx
+++ b/src/pages/SimulateurDevis.jsx
@@ -107,7 +107,7 @@ function SimulateurDevis() {
 
             {resultat !== null && (
               <div className="devis-result">
-                Estimation du coût : <strong>{resultat.toFixed(2)} € TTC</strong>
+                Estimation du coût : <strong>{resultat.toFixed(2)} € TTC</strong>
               </div>
             )}
           </form>


### PR DESCRIPTION
## Summary
- remove Vite template defaults that forced centered dark layout
- normalize French text spacing to satisfy ESLint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68960997a464832e927221ee85b3c64a